### PR TITLE
a couple minor fixes

### DIFF
--- a/src/CTBrowserWindowController.mm
+++ b/src/CTBrowserWindowController.mm
@@ -497,6 +497,9 @@ static CTBrowserWindowController* _currentMain = nil; // weak
   return ![self isFullscreen];
 }*/
 
+- (BOOL)isTabFullyVisible:(CTTabView*)tab {
+	return [tabStripController_ isTabFullyVisible:tab];
+}
 
 // impl. CTTabWindowController requirements
 - (void)setShowsNewTabButton:(BOOL)show {

--- a/src/chrome/browser/cocoa/CTTabView.mm
+++ b/src/chrome/browser/cocoa/CTTabView.mm
@@ -287,6 +287,7 @@ const CGFloat kRapidCloseDist = 2.5;
   sourceWindowFrame_ = [sourceWindow_ frame];
   sourceTabFrame_ = [self frame];
   ct_objc_xch(&sourceController_, [sourceWindow_ windowController]);
+  sourceController_.didShowNewTabButtonBeforeTemporalAction = sourceController_.showsNewTabButton;
   tabWasDragged_ = NO;
   tearTime_ = 0.0;
   draggingWithinTabStrip_ = YES;

--- a/src/chrome/browser/cocoa/CTTabWindowController.mm
+++ b/src/chrome/browser/cocoa/CTTabWindowController.mm
@@ -254,7 +254,6 @@
 - (void)insertPlaceholderForTab:(CTTabView*)tab
                           frame:(NSRect)frame
                   yStretchiness:(CGFloat)yStretchiness {
-  didShowNewTabButtonBeforeTemporalAction_ = self.showsNewTabButton;
   self.showsNewTabButton = NO;
 }
 


### PR DESCRIPTION
1) Fixed a bug where the newTabButton would stay hidden after dragging a tab: 
'insertPlaceholderForTab:frame:yStretchiness:' is called on each CTTabView mouseDrag event, so setting didShowNewTabButtonBeforeTemporalAction here is problematic -- after the second mouseDrag, this will always be NO, and the newTabButton will never reappear.  I simply moved the setting of this property to the mouseDown handler.

2) Dragging a tab straight to the left or right now tears it off the window (as in Chrome)
