### PR TITLE
Using const NSString * as an lvalue where NSString * was expected

### DIFF
--- a/src/CTTabContents.h
+++ b/src/CTTabContents.h
@@ -4,7 +4,7 @@
 class CTTabStripModel;
 @class CTBrowser;
 
-extern const NSString* CTTabContentsDidCloseNotification;
+#define CTTabContentsDidCloseNotification @"CTTabContentsDidCloseNotification"
 
 //
 // Visibility states:

--- a/src/CTTabContents.mm
+++ b/src/CTTabContents.mm
@@ -3,8 +3,8 @@
 #import "CTBrowser.h"
 #import "KVOChangeScope.hh"
 
-const NSString* CTTabContentsDidCloseNotification =
-    @"CTTabContentsDidCloseNotification";
+//static NSString* CTTabContentsDidCloseNotification =
+//    @"CTTabContentsDidCloseNotification";
 
 @implementation CTTabContents
 


### PR DESCRIPTION
I tried compiling head and kept getting a compile error which I'd never seen before. Xcode was complaining that a const NSString \* was being passed in for an NSString *. I don't understand how that can be an error, but my C is not my main language. I'm using Xcode 4, so I'm guessing this is a constraint that clang added, but again, I'm a little out of my depth here.

I'm guessing this isn't the best way to do this (since I'm assuming this would lead to a new @"CTTabContentsDidCloseNotification" being alloc'd every time CTTabContentsDidCloseNotification is used), but I wanted to bring this to your attention. The bundled example works with this patch.

Thanks!
