### PR TITLE
XCode 4 compilation fixes

### DIFF
--- a/src/CTTabContents.h
+++ b/src/CTTabContents.h
@@ -4,7 +4,7 @@
 class CTTabStripModel;
 @class CTBrowser;
 
-extern const NSString* CTTabContentsDidCloseNotification;
+extern NSString* const CTTabContentsDidCloseNotification;
 
 //
 // Visibility states:

--- a/src/CTTabContents.mm
+++ b/src/CTTabContents.mm
@@ -3,7 +3,7 @@
 #import "CTBrowser.h"
 #import "KVOChangeScope.hh"
 
-const NSString* CTTabContentsDidCloseNotification =
+NSString* const CTTabContentsDidCloseNotification =
     @"CTTabContentsDidCloseNotification";
 
 @implementation CTTabContents


### PR DESCRIPTION
XCode was complaining that const NSString\* is not a valid thing to pass as a parameter in some places involving notificationcenters. NSString\* const make XCode4 a lot happier.
